### PR TITLE
Fix content type checking for FKB 1.44+

### DIFF
--- a/fullykiosk/__init__.py
+++ b/fullykiosk/__init__.py
@@ -142,6 +142,10 @@ class _RequestsHandler:
                 )
                 raise FullyKioskError(response.status, await response.text())
 
-            data = await response.json(content_type="text/html")
+            try:
+                data = await response.json()
+            except aiohttp.client_exceptions.ContentTypeError:
+                data = await response.json(content_type="text/html")
+
             _LOGGER.debug(json.dumps(data))
             return data


### PR DESCRIPTION
Old versions of FKB returned Content-Type: text/html and changed to Content-Type: application/json as of 1.44. This updated the JSON decoding to work with both instead of failing.